### PR TITLE
Add intake app version as a parameter and send it to the Integration deploy job

### DIFF
--- a/JenkinsfileSmokeAcceptanceTests
+++ b/JenkinsfileSmokeAcceptanceTests
@@ -29,7 +29,9 @@ node ('preint') {
     parameters([
       string(defaultValue: 'xvfb_firefox', description: 'Name of the capybara driver, options include: webkit, xvfb_firefox', name: 'CAPYBARA_DRIVER'),
       string(defaultValue: 'smoke', description: 'The set of tests, each set can be found in feature_set.yml', name: 'FEATURE_SET'),
-      string(defaultValue: 'https://web.preint.cwds.io', description: 'Target URL to run the tests', name: 'APP_URL')]),pipelineTriggers([])])
+      string(defaultValue: 'https://web.preint.cwds.io', description: 'Target URL to run the tests', name: 'APP_URL'),
+      string(defaultValue: 'latest', description: 'Target URL to run the tests', name: 'INTAKE_APP_VERSION')]),pipelineTriggers([])
+    ])
 
   def errorcode = null;
   def buildInfo = '';
@@ -55,7 +57,7 @@ node ('preint') {
     stage ('Integration Env Deploy') {
                build job: '/Integration Environment/deploy-intake-app/',
                    parameters: [
-                   string(name: 'INTAKE_APP_VERSION', value: "latest"),
+                   string(name: 'INTAKE_APP_VERSION', value: INTAKE_APP_VERSION),
                    string(name: 'inventory', value: 'inventories/integration/hosts.yml')
                    ],
                    wait: false


### PR DESCRIPTION
[FIT-44 pass intake version to integration jobs](https://osi-cwds.atlassian.net/browse/FIT-44)

This will make exact version deploys to integration afterwards, and will help to build a version manifest.
