### PR TITLE
Possibly stop driver crashes?

### DIFF
--- a/spec/smoke/intake_dashboard_ready_spec.rb
+++ b/spec/smoke/intake_dashboard_ready_spec.rb
@@ -8,10 +8,6 @@ describe 'Dashboard Ready', type: :feature do
     login_user
   end
 
-  after do
-    clear_user_login
-  end
-
   it 'has a Start Screening link' do
     expect(page).to have_button('Start Screening')
   end


### PR DESCRIPTION
I don't love this. It will probably have adverse effects on other test suites. For now, though, it crashes the web driver, so let's remove it and see if our tests can go forward.