### PR TITLE
Wait for login to occur before continuing

### DIFF
--- a/spec/helpers/login_helper.rb
+++ b/spec/helpers/login_helper.rb
@@ -18,6 +18,7 @@ def fill_in_credentials(user)
   user = user.to_json if user.is_a?(Hash)
   fill_in('username', with: ENV.fetch('ACCEPTANCE_TEST_USER', user))
   click_button('Sign In')
+  expect(page).not_to have_button('Sign In')
   $current_user = JSON.parse(user, object_class: OpenStruct)
 end
 


### PR DESCRIPTION
Sometimes, after filling out the Perry login form, it can take a
few seconds for the authorization to happen and the page to
successfully redirect. If we immediately try to navigate to a page
within the app, we may not actually have gotten a token, causing
our login to effectively fail. This change adds a delay, waiting
until we are on some page that does not have a Sign In button (in
this case the dashboard).