### PR TITLE
Use the available global $ for jquery

### DIFF
--- a/spec/helpers/wait_for_ajax.rb
+++ b/spec/helpers/wait_for_ajax.rb
@@ -9,7 +9,7 @@ module WaitForAjax
   module_function :wait_for_ajax
 
   def finished_all_ajax_requests?
-    page.evaluate_script('jQuery.active').zero?
+    page.evaluate_script('$.active').zero?
   end
   module_function :finished_all_ajax_requests?
 end


### PR DESCRIPTION
After login, i was using wait_for_ajax using 'jQuery.active' to execute next steps for Capybara testing.  However, the jQuery function is not available immediately following sign up.

To fix the issue, using the available global function '$' to check for any active ajax requests.