### PR TITLE
Skip maximizing browser window for headless chrome

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,9 @@ end
 
 Capybara.javascript_driver = :headless_chrome
 
-Capybara.page.driver.browser.manage.window.maximize
+unless Capybara.current_driver == :headless_chrome
+  Capybara.page.driver.browser.manage.window.maximize
+end
 
 # capybara session
 module Capybara


### PR DESCRIPTION
Address the following bug when acceptance test is run in the pipeline
* `unknown error: unhandled inspector error: {"code":-32601,"message":"'Browser.getWindowForTarget' wasn't found"} (Selenium::WebDriver::Error::UnknownError)`