### PR TITLE
Redirect from confirmation page

### DIFF
--- a/spec/helpers/login_helper.rb
+++ b/spec/helpers/login_helper.rb
@@ -16,6 +16,7 @@ def fill_in_login(user, password)
 
   if password.present?
     Capybara.find_field('signInSubmitButton').click
+    redirect_from_confirmation_page
   else
     Capybara.click_button('Sign In')
     WaitForAjax.wait_for_ajax
@@ -49,6 +50,10 @@ def redirect_to_intented_path(path)
   else
     Capybara.visit path
   end
+end
+
+def redirect_from_confirmation_page
+  Capybara.click_button('Sign In as') if Capybara.has_button?('Sign In as')
 end
 
 def logout_user


### PR DESCRIPTION
On Edge, token is not being cleared.

This can happen on any browser, but we are seeing the behavior only on Edge when running tests.