### PR TITLE
Lockdown intake_testing_base_image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cwds/intake_testing_base_image:latest
+FROM cwds/intake_testing_base_image:2.1
 LABEL application=acceptance_black_box
 RUN bundle config --global frozen 1
 WORKDIR /usr/src/app


### PR DESCRIPTION
lockdown the testing base image to the current version so that tests don't break when Im upgrading firefox in base image version 2.2