### PR TITLE
Make sure the test run exit code is returned properly

### DIFF
--- a/scripts/ci/acceptance_testing_run.rb
+++ b/scripts/ci/acceptance_testing_run.rb
@@ -4,6 +4,6 @@
 Dir.chdir('bubble') do
   `docker-compose -p acceptance_bubble_#{ENV['BUILD_NUMBER']} -f docker-compose.bubble.yml up -d nginx intake`
   `docker-compose -p acceptance_bubble_#{ENV['BUILD_NUMBER']} -f docker-compose.bubble.yml build acceptance_testing`
-  exec("docker-compose -p acceptance_bubble_#{ENV['BUILD_NUMBER']} -f docker-compose.bubble.yml up acceptance_testing")
+  exec("docker-compose -p acceptance_bubble_#{ENV['BUILD_NUMBER']} -f docker-compose.bubble.yml up --exit-code-from acceptance_testing acceptance_testing")
 end
 


### PR DESCRIPTION
This fixes acceptance tests so that they don't silently fail. however, it does not fix the actual failure.

docker-compose needs to be at least version 1.12 for this to work